### PR TITLE
feat: Update Remove Room from Venue Logic by Removing Venue ID from R…

### DIFF
--- a/venue-manager/src/main/java/evrentan/community/venuemanager/controller/RoomController.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/controller/RoomController.java
@@ -172,8 +172,7 @@ public class RoomController {
    * REST end-point in order to add room(s) to a specific venue object by venue ID.
    * Details related to API specs can be found in the API Documentation which can be reached as described in README file.
    *
-   * @param venueId is the venue id that is going to be updated.
-   * @param removedVenueRoom is the new object that is going to be added to the existing one. Please, see the {@link VenueRoom} class for details.
+   * @param id is the room id that is going to be removed.
    * @return ResponseEntity. Please, see the {@link ResponseEntity} class for details.
    *
    * @author <a href="https://github.com/evrentan">Evren Tan</a>
@@ -187,8 +186,8 @@ public class RoomController {
       @ApiResponse(responseCode  = "404", description  = "Not Found"),
       @ApiResponse(responseCode  = "500", description  = "Internal Server Error")
   })
-  public ResponseEntity removeRoom(@RequestParam(value = "id") @NotNull UUID venueId, @RequestBody @NotNull VenueRoom removedVenueRoom) {
-    this.roomService.removeFromVenueByVenueId(venueId, removedVenueRoom);
+  public ResponseEntity removeRoom(@RequestParam(value = "id") @NotNull UUID id) {
+    this.roomService.removeFromVenue(id);
     return ResponseEntity.accepted().build();
   }
 }

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/impl/RoomServiceImpl.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/impl/RoomServiceImpl.java
@@ -144,20 +144,22 @@ public class RoomServiceImpl implements evrentan.community.venuemanager.service.
   /**
    * Remove a room from a venue
    *
-   * @param roomId room id to be removed to the venue
-   * @param removedVenueRoom venue that the room is removed from
+   * @param id room id to be removed to the venue
    *
    * @author <a href="https://github.com/evrentan">Evren Tan</a>
    * @since 1.0.0
    */
-  public void removeFromVenueByVenueId(UUID roomId, VenueRoom removedVenueRoom) {
-    this.checkRoomExists(roomId);
-    this.venueService.checkVenueExists(removedVenueRoom.getVenueId());
-    List<VenueRoom> venueRoomList = VenueRoomMapper.toDtoList(this.venueRoomRepository.findAllByVenueIdAndRoomIdInAndActive(removedVenueRoom.getVenueId(), Collections.singletonList(roomId), true));
+  public void removeFromVenue(UUID id) {
+    this.checkRoomExists(id);
+    List<VenueRoom> relatedVenueRoom = VenueRoomMapper.toDtoList(this.venueRoomRepository.findAllByRoomIdAndActive(id, true));
+    this.venueService.checkVenueExists(Optional.ofNullable(relatedVenueRoom.get(0).getVenueId()).orElse(null));
 
-    venueRoomList.forEach(venueRoom -> venueRoom.setActive(false));
+    List<VenueRoom> venueRoomList = VenueRoomMapper.toDtoList(this.venueRoomRepository.findAllByVenueIdAndRoomIdInAndActive(relatedVenueRoom.get(0).getVenueId(), Collections.singletonList(id), true));
 
-    this.venueRoomRepository.saveAll(VenueRoomMapper.toEntityList(venueRoomList));
+    if (!venueRoomList.isEmpty()) {
+      venueRoomList.forEach(venueRoom -> venueRoom.setActive(false));
+      this.venueRoomRepository.saveAll(VenueRoomMapper.toEntityList(venueRoomList));
+    }
   }
 
   /**

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/service/RoomService.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/service/RoomService.java
@@ -84,11 +84,10 @@ public interface RoomService {
   /**
    * Remove a room from a venue
    *
-   * @param roomId room id to be removed to the venue
-   * @param removedVenueRoom venue that the room is removed from
+   * @param id room id to be removed to the venue
    *
    * @author <a href="https://github.com/evrentan">Evren Tan</a>
    * @since 1.0.0
    */
-  void removeFromVenueByVenueId(UUID roomId, VenueRoom removedVenueRoom);
+  void removeFromVenue(UUID id);
 }


### PR DESCRIPTION
…equest

feat: Update Remove Room from Venue Logic by Removing Venue ID from Request

Update Remove Room from Venue Logic.
Venue ID information is sent in the as-is architecture but there is no need to send venue id as the association between venue & room is 1-to-1.
VenueRoom object should be removed from request body of removeFromVenue API.