### PR TITLE
[Feature]: Upgrade to Spring Boot 3.0.0 #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Please check the [Contributors List](CONTRIBUTORS.md) to see who makes this open
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [PostgreSQL][postgresql-version]
 - [Flyway Migration][flyway-migration]
 - Eureka Client
@@ -55,7 +55,7 @@ GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
 Please check the [LICENSE](LICENSE) file for more details.
 
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [postgresql-version]: https://www.postgresql.org/

--- a/api-gateway/README.md
+++ b/api-gateway/README.md
@@ -34,9 +34,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.7.1][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [Spring Cloud Config Server][spring-cloud-config-server]
 - Eureka Client
 - Spring Boot Actuator
@@ -92,7 +92,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [spring-cloud-config-server]: https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html

--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -14,10 +14,13 @@ springBoot {
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
 }
 
 ext {
-    set('springCloudVersion', "2021.0.3")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {

--- a/api-gateway/src/main/java/evrentan/community/apigateway/spring/config/ServiceDiscoveryClientConfig.java
+++ b/api-gateway/src/main/java/evrentan/community/apigateway/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.apigateway.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/api-gateway/src/main/java/evrentan/community/apigateway/spring/spring/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/evrentan/community/apigateway/spring/spring/ApiGatewayApplication.java
@@ -1,12 +1,9 @@
 package evrentan.community.apigateway.spring.spring;
 
-import evrentan.community.apigateway.spring.config.ServiceDiscoveryClientConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import(value = {ServiceDiscoveryClientConfig.class})
 public class ApiGatewayApplication {
 
   public static void main(String[] args) {

--- a/community-manager/README.md
+++ b/community-manager/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - Eureka Client
 - Spring Cloud Config Server
 - Spring Boot Actuator
@@ -90,7 +90,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [contributor]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg

--- a/community-manager/build.gradle
+++ b/community-manager/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -20,10 +20,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
@@ -32,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.4'

--- a/community-manager/src/main/java/evrentan/community/communitymanager/entity/CommunityEntity.java
+++ b/community-manager/src/main/java/evrentan/community/communitymanager/entity/CommunityEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.communitymanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import java.util.UUID;
 
 /**

--- a/community-manager/src/main/java/evrentan/community/communitymanager/spring/config/ServiceDiscoveryClientConfig.java
+++ b/community-manager/src/main/java/evrentan/community/communitymanager/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.communitymanager.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/community-manager/src/main/java/evrentan/community/communitymanager/spring/spring/CommunityManagerApplication.java
+++ b/community-manager/src/main/java/evrentan/community/communitymanager/spring/spring/CommunityManagerApplication.java
@@ -6,11 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import(value = {CommonConfig.class
-    , WebConfig.class
-    , TransactionManagementConfig.class
-    , SwaggerConfig.class
-    , ServiceDiscoveryClientConfig.class})
+@Import(value = {CommonConfig.class,
+    WebConfig.class,
+    TransactionManagementConfig.class,
+    SwaggerConfig.class})
 public class CommunityManagerApplication {
 
   public static void main(String[] args) {

--- a/config-server/README.md
+++ b/config-server/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [Spring Cloud Config Server][spring-cloud-config-server]
 - Eureka Client
 - Spring Boot Actuator
@@ -88,7 +88,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [spring-cloud-config-server]: https://cloud.spring.io/spring-cloud-config/multi/multi__spring_cloud_config_server.html

--- a/config-server/build.gradle
+++ b/config-server/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -14,12 +14,13 @@ springBoot {
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.spring.io/snapshot' }
-    maven { url 'https://repo.spring.io/milestone' }
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
 }
 
 ext {
-    set('springCloudVersion', "2021.0.3-SNAPSHOT")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {

--- a/config-server/src/main/java/evrentan/community/configserver/spring/config/ServiceDiscoveryClientConfig.java
+++ b/config-server/src/main/java/evrentan/community/configserver/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.configserver.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/config-server/src/main/java/evrentan/community/configserver/spring/spring/ConfigServerApplication.java
+++ b/config-server/src/main/java/evrentan/community/configserver/spring/spring/ConfigServerApplication.java
@@ -1,14 +1,12 @@
 package evrentan.community.configserver.spring.spring;
 
 import evrentan.community.configserver.spring.config.ConfigServerConfig;
-import evrentan.community.configserver.spring.config.ServiceDiscoveryClientConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import(value = {ConfigServerConfig.class
-    , ServiceDiscoveryClientConfig.class})
+@Import(value = {ConfigServerConfig.class})
 public class ConfigServerApplication {
 
   public static void main(String[] args) {

--- a/db-migration-manager/README.md
+++ b/db-migration-manager/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [Flyway Migration][flyway-migration]
 - Eureka Client
 - Spring Cloud Config Server
@@ -89,7 +89,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [flyway-migration]: https://flywaydb.org/documentation/

--- a/db-migration-manager/build.gradle
+++ b/db-migration-manager/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -10,15 +10,29 @@ sourceCompatibility = '17'
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
+}
+
+ext {
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.flywaydb:flyway-core'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/event-manager/README.md
+++ b/event-manager/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - Eureka Client
 - Spring Cloud Config Server
 - Spring Boot Actuator
@@ -90,7 +90,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [contributor]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg

--- a/event-manager/build.gradle
+++ b/event-manager/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.4'

--- a/event-manager/src/main/java/evrentan/community/eventmanager/spring/config/ServiceDiscoveryClientConfig.java
+++ b/event-manager/src/main/java/evrentan/community/eventmanager/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.eventmanager.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/event-manager/src/main/java/evrentan/community/eventmanager/spring/spring/EventManagerApplication.java
+++ b/event-manager/src/main/java/evrentan/community/eventmanager/spring/spring/EventManagerApplication.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @Import(value = {CommonConfig.class,
-    ServiceDiscoveryClientConfig.class,
     SwaggerConfig.class,
     TransactionManagementConfig.class,
     WebConfig.class})

--- a/service-discovery/README.md
+++ b/service-discovery/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - Eureka Server
 - Spring Cloud Config Server
 - Spring Boot Actuator
@@ -89,7 +89,7 @@ GNU General Public License v3.0
 Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [contributor]: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg

--- a/service-discovery/build.gradle
+++ b/service-discovery/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -17,7 +17,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {

--- a/user-manager/README.md
+++ b/user-manager/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [PostgreSQL][postgresql-version]
 - Eureka Client
 - Spring Cloud Config Server
@@ -91,7 +91,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [postgresql-version]: https://www.postgresql.org/

--- a/user-manager/build.gradle
+++ b/user-manager/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -20,10 +20,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
@@ -32,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.4'

--- a/user-manager/src/main/java/evrentan/community/usermanager/entity/ApplicationUserEntity.java
+++ b/user-manager/src/main/java/evrentan/community/usermanager/entity/ApplicationUserEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.usermanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import javax.validation.constraints.Pattern;
 import java.util.UUID;
 

--- a/user-manager/src/main/java/evrentan/community/usermanager/entity/UserTypeEntity.java
+++ b/user-manager/src/main/java/evrentan/community/usermanager/entity/UserTypeEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.usermanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import javax.validation.constraints.Pattern;
 import java.util.UUID;
 

--- a/user-manager/src/main/java/evrentan/community/usermanager/spring/config/ServiceDiscoveryClientConfig.java
+++ b/user-manager/src/main/java/evrentan/community/usermanager/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.usermanager.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/user-manager/src/main/java/evrentan/community/usermanager/spring/spring/UserManagerApplication.java
+++ b/user-manager/src/main/java/evrentan/community/usermanager/spring/spring/UserManagerApplication.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @Import(value = {CommonConfig.class
-    , ServiceDiscoveryClientConfig.class
     , SwaggerConfig.class
     , TransactionManagementConfig.class
     , WebConfig.class})

--- a/venue-manager/README.md
+++ b/venue-manager/README.md
@@ -32,9 +32,9 @@ Below you can find the names of the contributors to this project;
 
 For building and running the application belows are required;
 
-- [Spring Boot 2.6.6][spring-boot-version]
+- [Spring Boot 3.0.0][spring-boot-version]
 - [JDK 17][java-version]
-- [Gradle 7.3 or above][gradle-version]
+- [Gradle 7.6 or above][gradle-version]
 - [PostgreSQL][postgresql-version]
 - Eureka Client
 - Spring Cloud Config Server
@@ -91,7 +91,7 @@ Permissions of this strong copyleft license are conditioned on making available 
 Please check the [LICENSE](LICENSE) file for more details.
 
 [evren-tan-github]: https://github.com/evrentan
-[spring-boot-version]: https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now
+[spring-boot-version]: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes
 [java-version]: https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 [gradle-version]: https://gradle.org/releases/
 [postgresql-version]: https://www.postgresql.org/

--- a/venue-manager/build.gradle
+++ b/venue-manager/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -20,10 +20,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/snapshot" }
+    maven { url "https://repo.spring.io/milestone" }
+    maven { url "https://repo.spring.io/release" }
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.0")
 }
 
 dependencies {
@@ -32,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.4'

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/entity/RoomEntity.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/entity/RoomEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.venuemanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import java.util.UUID;
 
 /**

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/entity/VenueEntity.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/entity/VenueEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.venuemanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import java.util.UUID;
 
 /**

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/entity/VenueRoomEntity.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/entity/VenueRoomEntity.java
@@ -1,8 +1,8 @@
 package evrentan.community.venuemanager.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
-import javax.persistence.*;
 import java.util.UUID;
 
 /**

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/spring/config/ServiceDiscoveryClientConfig.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/spring/config/ServiceDiscoveryClientConfig.java
@@ -1,9 +1,0 @@
-package evrentan.community.venuemanager.spring.config;
-
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableEurekaClient
-public class ServiceDiscoveryClientConfig {
-}

--- a/venue-manager/src/main/java/evrentan/community/venuemanager/spring/spring/VenueManagerApplication.java
+++ b/venue-manager/src/main/java/evrentan/community/venuemanager/spring/spring/VenueManagerApplication.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @Import(value = {CommonConfig.class
-    , ServiceDiscoveryClientConfig.class
     , SwaggerConfig.class
     , TransactionManagementConfig.class
     , WebConfig.class})


### PR DESCRIPTION
[Feature]: Upgrade to Spring Boot 3.0.0 #65

- Upgrade to Spring Boot 3.0.0
   - Upgrade Spring Boot 3.0.0
   - Upgrade Spring Cloud 2022.0.0
   - Remove Eureka Client Configuration as it is not required any more
   - Switch to jakarta.persistence from javax.persistence
   - Add Hibernate Validator
   - Add Spring Maven Repos
- Upgrade Gradle 7.6

Closes #65