### PR TITLE
[Feature]: Create Schemas According to Service Name #82

### DIFF
--- a/config-server-data/community-manager/community-manager-dev.properties
+++ b/config-server-data/community-manager/community-manager-dev.properties
@@ -3,7 +3,7 @@ server.port = 8081
 
 # Datasource Settings
 spring.datasource.driver-class-name = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/community-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/community-manager-db?currentSchema=community-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/community-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = community-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/community-manager/community-manager-local.properties
+++ b/config-server-data/community-manager/community-manager-local.properties
@@ -3,7 +3,7 @@ server.port = 8081
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/community-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/community-manager-db?currentSchema=community-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/community-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = community-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/event-manager/event-manager-dev.properties
+++ b/config-server-data/event-manager/event-manager-dev.properties
@@ -3,7 +3,7 @@ server.port = 8201
 
 # Datasource Settings
 spring.datasource.driver-class-name = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/event-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/event-manager-db?currentSchema=event-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/event-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = event-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/event-manager/event-manager-local.properties
+++ b/config-server-data/event-manager/event-manager-local.properties
@@ -3,7 +3,7 @@ server.port = 8201
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/event-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/event-manager-db?currentSchema=event-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/event-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = event-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/user-manager/user-manager-dev.properties
+++ b/config-server-data/user-manager/user-manager-dev.properties
@@ -3,7 +3,7 @@ server.port = 8091
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/user-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/user-manager-db?currentSchema=user-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/user-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = user-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/user-manager/user-manager-local.properties
+++ b/config-server-data/user-manager/user-manager-local.properties
@@ -3,7 +3,7 @@ server.port = 8091
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/user-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/user-manager-db?currentSchema=user-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/user-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = user-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/venue-manager/venue-manager-dev.properties
+++ b/config-server-data/venue-manager/venue-manager-dev.properties
@@ -3,7 +3,7 @@ server.port = 8101
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/venue-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/venue-manager-db?currentSchema=venue-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/venue-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = venue-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server

--- a/config-server-data/venue-manager/venue-manager-local.properties
+++ b/config-server-data/venue-manager/venue-manager-local.properties
@@ -3,7 +3,7 @@ server.port = 8101
 
 # Datasource Settings
 spring.datasource.driverClassName = org.postgresql.Driver
-spring.datasource.url = jdbc:postgresql://localhost:5432/venue-manager-db
+spring.datasource.url = jdbc:postgresql://localhost:5432/venue-manager-db?currentSchema=venue-manager
 spring.datasource.username = admin
 spring.datasource.password = admin
 
@@ -29,7 +29,7 @@ spring.flyway.enabled = true
 spring.flyway.url = jdbc:postgresql://localhost:5432/venue-manager-db
 spring.flyway.user = admin
 spring.flyway.password = admin
-spring.flyway.schemas = public
+spring.flyway.schemas = venue-manager
 spring.flyway.baseline-on-migrate = true
 
 #Discovery server


### PR DESCRIPTION
[Feature]: Create Schemas According to Service Name #82

Create Schemas According to Service Name instead of using public schema. Schema names will be as below per DB;

- community-manager-db --> community-manager
- event-manager-db --> event-manager
- user-manager-db --> user-manager
- venue-manager-db --> venue-manager

Updated application.properties files accordingly.

Closes #82